### PR TITLE
fix issue with Webpack's CaseSensitivePathsPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This package implements the [es-shim API](https://github.com/es-shims/api) inter
 
 Most common usage:
 ```js
-var globalThis = require('globalThis')(); // returns native method if compliant
+var globalThis = require('globalthis')(); // returns native method if compliant
 	/* or */
-var globalThis = require('globalThis/polyfill')(); // returns native method if compliant
+var globalThis = require('globalthis/polyfill')(); // returns native method if compliant
 ```
 
 ## Example


### PR DESCRIPTION
```This Webpack plugin enforces the entire path of all required modules match the exact case of the actual path on disk. Using this plugin helps alleviate cases where developers working on OSX, which does not follow strict path case sensitivity, will cause conflicts with other developers or build boxes running other operating systems which require correctly cased paths.```

https://github.com/Urthen/case-sensitive-paths-webpack-plugin

![Screenshot_72](https://user-images.githubusercontent.com/1275228/58752509-7d25f800-84b8-11e9-8c8f-a260f283b219.png)
